### PR TITLE
Check shouldCreate prop before running

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -23,13 +23,18 @@ module.exports = Generator.extend({
 
     var prompts = [{
       type: 'confirm',
-      name: 'someAnswer',
+      name: 'shouldCreate',
       message: 'Create ' + featureName + ' folder in ' + this.destinationRoot() + ' ?',
       default: true
     }];
 
-    return this.prompt(prompts).then(function (props) {
-      // To access props later use this.props.someAnswer;
+    return this.prompt(prompts)
+    .then(function (props) {
+      if (!props.shouldCreate) {
+        console.log('Generator cancelled.');
+        process.exit(1);
+      }
+      // To access props later use this.props.`property`;
       this.props = props;
     }.bind(this));
   },


### PR DESCRIPTION
Previously the user input confirm step was not being checked
and the feature folder would always be created.

This change exits the process if the user does not confirm.